### PR TITLE
Use target_capacity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ resource "aws_ecs_capacity_provider" "main" {
       maximum_scaling_step_size = 1000
       minimum_scaling_step_size = 1
       status                    = "ENABLED"
-      target_capacity           = 10
+      target_capacity           = var.target_capacity
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,24 +53,24 @@ variable "root_block_device_volume_size" {
   default     = 32
 }
 
-variable "target_capacity" {
-  type        = number
-  description = "The target utilization for the capacity provider. A number between 1 and 100."
-  default     = 50
-}
-
 variable "subnet_ids" {
   type        = list(string)
   description = "The ids of the VPC subnets used by the EC2 instances in the ECS cluster."
-}
-
-variable "vpc_id" {
-  type        = string
-  description = "The id of the VPC used by the EC2 instances in the ECS cluster."
 }
 
 variable "tags" {
   type        = map(string)
   description = "Tags applied to resources part of the ECS Cluster."
   default     = {}
+}
+
+variable "target_capacity" {
+  type        = number
+  description = "The target utilization for the capacity provider. A number between 1 and 100."
+  default     = 50
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The id of the VPC used by the EC2 instances in the ECS cluster."
 }


### PR DESCRIPTION
The previous version did not use the target_capacity variable.  This PR fixes that bug.