### PR TITLE
Ignore changes to min and max size for autoscaling group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,7 @@ resource "aws_autoscaling_group" "main" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = [max_size, min_size]
   }
 }
 


### PR DESCRIPTION
This allows managing the autoscaling group by hand.