### PR TITLE
Ignore desired_capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ module "ecs_cluster" {
 }
 ```
 
+Changes to the desired\_capacity, min\_size, and max\_size configuration of the Auto Scaling group are ignored by Terraform.  These parameters can be updated via the AWS Console, API, or CLI.
+
 To connect to an EC2 instance that is part of the ECS cluster, set the subnet\_ids to public subnets and set the key\_name to the name of a key pair.
 
 ## Terraform Version

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,10 @@
  * }
  * ```
  *
+ * Changes to the desired_capacity, min_size, and max_size configuration of the Auto Scaling group are ignored by Terraform.  These parameters can be updated via the AWS Console, API, or CLI.
+ *
  * To connect to an EC2 instance that is part of the ECS cluster, set the subnet_ids to public subnets and set the key_name to the name of a key pair.
+ *
  *
  * ## Terraform Version
  *
@@ -114,7 +117,7 @@ resource "aws_autoscaling_group" "main" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [max_size, min_size]
+    ignore_changes        = [desired_capacity, max_size, min_size]
   }
 }
 


### PR DESCRIPTION
Ignore changes to desired_capacity configuration of the AWS Auto Scaling group.